### PR TITLE
Add domain type definitions

### DIFF
--- a/types/ai-verification.types.ts
+++ b/types/ai-verification.types.ts
@@ -1,0 +1,117 @@
+// AI-specific enums
+export enum AIRecoveryType {
+  RETRY_WITH_BACKOFF = 'RETRY_WITH_BACKOFF',
+  CIRCUIT_BREAKER = 'CIRCUIT_BREAKER',
+  FALLBACK_TO_CACHE = 'FALLBACK_TO_CACHE',
+  ALTERNATIVE_MODEL = 'ALTERNATIVE_MODEL',
+  GRACEFUL_DEGRADATION = 'GRACEFUL_DEGRADATION'
+}
+
+export enum AIErrorCategory {
+  API_TIMEOUT = 'API_TIMEOUT',
+  AUTHENTICATION_FAILURE = 'AUTHENTICATION_FAILURE',
+  RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED',
+  MODEL_UNAVAILABLE = 'MODEL_UNAVAILABLE',
+  INPUT_VALIDATION_ERROR = 'INPUT_VALIDATION_ERROR',
+  OUTPUT_PARSING_ERROR = 'OUTPUT_PARSING_ERROR'
+}
+
+export enum CascadeType {
+  TYPE_INFERENCE_CASCADE = 'TYPE_INFERENCE_CASCADE',
+  MODULE_BOUNDARY_CASCADE = 'MODULE_BOUNDARY_CASCADE',
+  ASYNC_BOUNDARY_CASCADE = 'ASYNC_BOUNDARY_CASCADE',
+  FRAMEWORK_CONTRACT_CASCADE = 'FRAMEWORK_CONTRACT_CASCADE'
+}
+
+export enum VerificationStepCategory {
+  COMPILATION = 'COMPILATION',
+  UNIT_TESTING = 'UNIT_TESTING',
+  INTEGRATION_TESTING = 'INTEGRATION_TESTING',
+  MANUAL_TESTING = 'MANUAL_TESTING',
+  CODE_REVIEW = 'CODE_REVIEW'
+}
+
+export enum Priority {
+  CRITICAL = 'CRITICAL',
+  HIGH = 'HIGH',
+  MEDIUM = 'MEDIUM',
+  LOW = 'LOW'
+}
+
+export enum DeploymentEnvironment {
+  DEVELOPMENT = 'DEVELOPMENT',
+  STAGING = 'STAGING',
+  PRODUCTION = 'PRODUCTION'
+}
+
+export enum DeploymentStrategy {
+  ROLLING = 'ROLLING',
+  BLUE_GREEN = 'BLUE_GREEN',
+  CANARY = 'CANARY'
+}
+
+export enum SeniorityLevel {
+  JUNIOR = 'JUNIOR',
+  MID = 'MID',
+  SENIOR = 'SENIOR',
+  STAFF = 'STAFF'
+}
+
+export enum ReviewerType {
+  SENIOR_DEVELOPER = 'SENIOR_DEVELOPER',
+  TECH_LEAD = 'TECH_LEAD',
+  ARCHITECT = 'ARCHITECT'
+}
+
+export enum MitigationStrategyType {
+  FEATURE_FLAGS = 'FEATURE_FLAGS',
+  PHASED_ROLLOUT = 'PHASED_ROLLOUT',
+  CIRCUIT_BREAKER = 'CIRCUIT_BREAKER'
+}
+
+export enum RiskFactorType {
+  ASYNC_COMPLEXITY = 'ASYNC_COMPLEXITY',
+  TYPE_SAFETY = 'TYPE_SAFETY',
+  COMPONENT_COMPLEXITY = 'COMPONENT_COMPLEXITY'
+}
+
+import type { EntityId, Timestamp } from './canonical-types.js';
+
+export interface AICLIConfig {
+  aiProvider: string;
+  modelName: string;
+  maxRetries: number;
+  timeout: number;
+}
+
+export interface AICLIContext {
+  config: AICLIConfig;
+  sessionId: EntityId;
+  correlationId: EntityId;
+}
+
+export interface TelemetryData {
+  timestamp: Timestamp;
+  operation: string;
+  duration: number;
+  success: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ScanCommandOptions {
+  directory: string;
+  recursive?: boolean;
+  includePatterns?: string[];
+}
+
+export interface AnalyzeCommandOptions {
+  files: string[];
+  depth?: 'shallow' | 'deep';
+  format?: 'json' | 'markdown';
+}
+
+export interface StatusCommandOptions {
+  checkAi?: boolean;
+  checkTools?: boolean;
+  healthCheck?: boolean;
+}

--- a/types/canonical-types.ts
+++ b/types/canonical-types.ts
@@ -24,7 +24,7 @@ import type {
   TransformationId,
   TransformationResult,
   ValidationError,
-} from '@types/canonical-types';
+} from './canonical-types.js';
 import {
   createApiError,
   createApiSuccess,
@@ -34,7 +34,7 @@ import {
   RiskLevel,
   validateInput,
   ValidationSchema,
-} from '@types/canonical-types';
+} from './canonical-types.js';
 
 // Pure Node.js imports - constitutional environment detection applied
 import { EventEmitter } from 'events';

--- a/types/migration-engine.types.ts
+++ b/types/migration-engine.types.ts
@@ -1,0 +1,76 @@
+import type {
+  ApiError,
+  FilePath,
+  Timestamp,
+  ValidationLevel,
+  OperationId,
+  EntityId,
+  TransformationStatus,
+} from './canonical-types.js';
+
+export interface PipelineParams {
+  validationLevel: ValidationLevel;
+  operationId: OperationId;
+  sessionId: EntityId;
+  dryRun: boolean;
+  projectRoot: FilePath;
+  timestamp: Timestamp;
+}
+
+export interface WorkflowPhase {
+  id: string;
+  name: string;
+  dependencies: string[];
+  executor: string;
+}
+
+export interface MigrationWorkflowContext {
+  sessionId: EntityId;
+  operationId: OperationId;
+  projectRoot: FilePath;
+  pipelineParams: PipelineParams;
+  timestamp: Timestamp;
+}
+
+export interface ConsolidationOptions {
+  validateStructure: boolean;
+  rollbackOnError: boolean;
+  businessImpactAnalysis: boolean;
+  validationLevel: ValidationLevel;
+  operationId: OperationId;
+  sessionId: EntityId;
+  dryRun: boolean;
+}
+
+export interface ConsolidationContext {
+  options: ConsolidationOptions;
+  timestamp: Timestamp;
+}
+
+export interface ConsolidationResult {
+  operationId: OperationId;
+  status: TransformationStatus;
+  filesProcessed: number;
+  errors: ApiError[];
+  duration: number;
+  timestamp: Timestamp;
+}
+
+export interface ReorganizationOptions {
+  validateStructure: boolean;
+  rollbackOnError: boolean;
+  businessImpactAnalysis: boolean;
+  validationLevel: ValidationLevel;
+  operationId: OperationId;
+  sessionId: EntityId;
+  dryRun: boolean;
+}
+
+export interface ReorganizationResult {
+  operationId: OperationId;
+  status: TransformationStatus;
+  filesReorganized: number;
+  errors: ApiError[];
+  duration: number;
+  timestamp: Timestamp;
+}


### PR DESCRIPTION
## Summary
- add new AI verification and migration engine type definitions
- adjust canonical type imports to reference the JS file

## Testing
- `npx tsc --noEmit` *(fails: cannot find Node types and missing exports)*

------
https://chatgpt.com/codex/tasks/task_e_684729417e50833383cab297bfe6e426